### PR TITLE
add support for multi-column joins to SQL::Abstract::Pg

### DIFF
--- a/lib/SQL/Abstract/Pg.pm
+++ b/lib/SQL/Abstract/Pg.pm
@@ -172,14 +172,17 @@ sub _table {
   my $sep = $self->{name_sep} // '';
   for my $join (@join) {
     puke 'join must be in the form [$table, $fk => $pk]' if @$join < 3;
-    my $type = @$join > 3 ? shift @$join : '';
-    my ($name, $fk, $pk) = @$join;
+    my $type = @$join%2 == 0 ? shift @$join : '';
+    my ($name, $fk, $pk, @morekeys) = @$join;
     $table
       .= $self->_sqlcase($type =~ /^-(.+)$/ ? " $1 join " : ' join ')
       . $self->_quote($name)
-      . $self->_sqlcase(' on ') . '('
-      . $self->_quote(index($fk, $sep) > 0 ? $fk : "$name.$fk") . ' = '
-      . $self->_quote(index($pk, $sep) > 0 ? $pk : "$table[0].$pk") . ')';
+      . $self->_sqlcase(' on ') . '(';
+    do {
+      $table .= $self->_quote(index($fk, $sep) > 0 ? $fk : "$name.$fk") . ' = '
+             . $self->_quote(index($pk, $sep) > 0 ? $pk : "$table[0].$pk")
+             . (@morekeys ? $self->_sqlcase(' and ') : ')');
+      } while ($fk, $pk, @morekeys) = @morekeys;
   }
 
   return $table;
@@ -289,6 +292,9 @@ for.
 
   # "select * from foo left join bar on (bar.foo_id = foo.id)"
   $abstract->select(['foo', [-left => 'bar', foo_id => 'id']]);
+
+  # "select * from foo left join bar on (bar.foo_id = foo.id and bar.foo_id2 = foo.id2)"
+  $abstract->select(['foo', [-left => 'bar', foo_id => 'id', foo_id2 => 'id2']]);
 
 =head2 ORDER BY
 

--- a/lib/SQL/Abstract/Pg.pm
+++ b/lib/SQL/Abstract/Pg.pm
@@ -172,17 +172,18 @@ sub _table {
   my $sep = $self->{name_sep} // '';
   for my $join (@join) {
     puke 'join must be in the form [$table, $fk => $pk]' if @$join < 3;
-    my $type = @$join%2 == 0 ? shift @$join : '';
+    my $type = @$join % 2 == 0 ? shift @$join : '';
     my ($name, $fk, $pk, @morekeys) = @$join;
     $table
       .= $self->_sqlcase($type =~ /^-(.+)$/ ? " $1 join " : ' join ')
       . $self->_quote($name)
       . $self->_sqlcase(' on ') . '(';
     do {
-      $table .= $self->_quote(index($fk, $sep) > 0 ? $fk : "$name.$fk") . ' = '
-             . $self->_quote(index($pk, $sep) > 0 ? $pk : "$table[0].$pk")
-             . (@morekeys ? $self->_sqlcase(' and ') : ')');
-      } while ($fk, $pk, @morekeys) = @morekeys;
+      $table
+        .= $self->_quote(index($fk, $sep) > 0 ? $fk : "$name.$fk") . ' = '
+        . $self->_quote(index($pk, $sep) > 0 ? $pk : "$table[0].$pk")
+        . (@morekeys ? $self->_sqlcase(' and ') : ')');
+    } while ($fk, $pk, @morekeys) = @morekeys;
   }
 
   return $table;

--- a/t/sql.t
+++ b/t/sql.t
@@ -164,6 +164,14 @@ is_deeply \@sql,
 is_deeply \@sql,
   ['SELECT * FROM "foo" JOIN "bar" ON ("foo"."id" = "bar"."foo_id")'],
   'right query';
+@sql = $abstract->select(['foo', ['bar', 'foo.id' => 'bar.foo_id',
+                                         'foo.id2' => 'bar.foo_id2']]);
+is_deeply \@sql,
+  ['SELECT * FROM "foo" JOIN "bar" ON ("foo"."id" = "bar"."foo_id"'
+                                   . ' AND "foo"."id2" = "bar"."foo_id2"'
+                                   . ')'
+  ],
+  'right query';
 @sql
   = $abstract->select(['foo', ['bar', foo_id => 'id'], ['baz', foo_id => 'id']
   ]);
@@ -184,6 +192,16 @@ is_deeply \@sql,
 @sql = $abstract->select(['foo', [-inner => 'bar', foo_id => 'id']]);
 is_deeply \@sql,
   ['SELECT * FROM "foo" INNER JOIN "bar" ON ("bar"."foo_id" = "foo"."id")'],
+  'right query';
+@sql = $abstract->select(['foo', [-left => 'bar', foo_id => 'id',
+                                                  foo_id2 => 'id2',
+                                                  foo_id3 => 'id3'
+  ]]);
+is_deeply \@sql,
+  ['SELECT * FROM "foo" LEFT JOIN "bar" ON ("bar"."foo_id" = "foo"."id"'
+                                        . ' AND "bar"."foo_id2" = "foo"."id2"'
+                                        . ' AND "bar"."foo_id3" = "foo"."id3"'
+                                        . ')'],
   'right query';
 
 # JOIN (unsupported value)

--- a/t/sql.t
+++ b/t/sql.t
@@ -164,14 +164,14 @@ is_deeply \@sql,
 is_deeply \@sql,
   ['SELECT * FROM "foo" JOIN "bar" ON ("foo"."id" = "bar"."foo_id")'],
   'right query';
-@sql = $abstract->select(['foo', ['bar', 'foo.id' => 'bar.foo_id',
-                                         'foo.id2' => 'bar.foo_id2']]);
+@sql
+  = $abstract->select([
+  'foo', ['bar', 'foo.id' => 'bar.foo_id', 'foo.id2' => 'bar.foo_id2']
+  ]);
 is_deeply \@sql,
-  ['SELECT * FROM "foo" JOIN "bar" ON ("foo"."id" = "bar"."foo_id"'
-                                   . ' AND "foo"."id2" = "bar"."foo_id2"'
-                                   . ')'
-  ],
-  'right query';
+  [   'SELECT * FROM "foo" JOIN "bar" ON ("foo"."id" = "bar"."foo_id"'
+    . ' AND "foo"."id2" = "bar"."foo_id2"' . ')'
+  ], 'right query';
 @sql
   = $abstract->select(['foo', ['bar', foo_id => 'id'], ['baz', foo_id => 'id']
   ]);
@@ -193,16 +193,15 @@ is_deeply \@sql,
 is_deeply \@sql,
   ['SELECT * FROM "foo" INNER JOIN "bar" ON ("bar"."foo_id" = "foo"."id")'],
   'right query';
-@sql = $abstract->select(['foo', [-left => 'bar', foo_id => 'id',
-                                                  foo_id2 => 'id2',
-                                                  foo_id3 => 'id3'
-  ]]);
+@sql
+  = $abstract->select([
+  'foo', [-left => 'bar', foo_id => 'id', foo_id2 => 'id2', foo_id3 => 'id3']
+  ]);
 is_deeply \@sql,
-  ['SELECT * FROM "foo" LEFT JOIN "bar" ON ("bar"."foo_id" = "foo"."id"'
-                                        . ' AND "bar"."foo_id2" = "foo"."id2"'
-                                        . ' AND "bar"."foo_id3" = "foo"."id3"'
-                                        . ')'],
-  'right query';
+  [   'SELECT * FROM "foo" LEFT JOIN "bar" ON ("bar"."foo_id" = "foo"."id"'
+    . ' AND "bar"."foo_id2" = "foo"."id2"'
+    . ' AND "bar"."foo_id3" = "foo"."id3"' . ')'
+  ], 'right query';
 
 # JOIN (unsupported value)
 eval { $abstract->select(['foo', []]) };


### PR DESCRIPTION
I have a need to do SQL joins on tables using composite keys, but the current SQL::Abstract::Pg module only supports joining on a single key.  This adds support for multiple keys, with the following syntax.  

    $pg->abstract->select(['foo', ['bar', 'foo.id' => 'bar.foo_id', 'foo.id2' => 'bar.foo_id2']]);

to yield

    SELECT * FROM "foo" JOIN "bar" ON ("foo"."id" = "bar"."foo_id" AND "foo"."id2" = "bar"."foo_id2")
    
It's fairly straightforward, but I have one concern worth considering:

The argument to the `select` (the `$source` argument) is a reference to an array.  In SQL::Abstract, the general convention is "[things in arrays are OR'ed, and things in hashes are AND'ed](https://metacpan.org/pod/SQL::Abstract#Introduction)".  This PR assumes AND'ing the keys used in the join.  It suits my needs, but is this a serious infraction of the SQL::Abstract convention, or does it not need to apply because this is specific to the join condition?