### PR TITLE
Stop SQL::Abstract::Pg mutating inputs

### DIFF
--- a/lib/SQL/Abstract/Pg.pm
+++ b/lib/SQL/Abstract/Pg.pm
@@ -172,8 +172,9 @@ sub _table {
   my $sep = $self->{name_sep} // '';
   for my $join (@join) {
     puke 'join must be in the form [$table, $fk => $pk]' if @$join < 3;
-    my $type = @$join % 2 == 0 ? shift @$join : '';
-    my ($name, $fk, $pk, @morekeys) = @$join;
+    my @thisjoin = @$join;
+    my $type = @thisjoin % 2 == 0 ? shift @thisjoin : '';
+    my ($name, $fk, $pk, @morekeys) = @thisjoin;
     $table
       .= $self->_sqlcase($type =~ /^-(.+)$/ ? " $1 join " : ' join ')
       . $self->_quote($name)

--- a/t/sql.t
+++ b/t/sql.t
@@ -203,6 +203,8 @@ my $leftjoin_outputs =
   ];
 @sql = $abstract->select($leftjoin_inputs);
 is_deeply \@sql, $leftjoin_outputs, 'right query';
+@sql = $abstract->select($leftjoin_inputs);
+is_deeply \@sql, $leftjoin_outputs, 'right query second time';
 
 # JOIN (unsupported value)
 eval { $abstract->select(['foo', []]) };

--- a/t/sql.t
+++ b/t/sql.t
@@ -193,15 +193,16 @@ is_deeply \@sql,
 is_deeply \@sql,
   ['SELECT * FROM "foo" INNER JOIN "bar" ON ("bar"."foo_id" = "foo"."id")'],
   'right query';
-@sql
-  = $abstract->select([
+my $leftjoin_inputs = [
   'foo', [-left => 'bar', foo_id => 'id', foo_id2 => 'id2', foo_id3 => 'id3']
-  ]);
-is_deeply \@sql,
+  ];
+my $leftjoin_outputs =
   [   'SELECT * FROM "foo" LEFT JOIN "bar" ON ("bar"."foo_id" = "foo"."id"'
     . ' AND "bar"."foo_id2" = "foo"."id2"'
     . ' AND "bar"."foo_id3" = "foo"."id3"' . ')'
-  ], 'right query';
+  ];
+@sql = $abstract->select($leftjoin_inputs);
+is_deeply \@sql, $leftjoin_outputs, 'right query';
 
 # JOIN (unsupported value)
 eval { $abstract->select(['foo', []]) };


### PR DESCRIPTION
### Summary
Stop `SQL::Abstract::Pg->select` mutating its inputs on non-inner joins, by copying the input and `shift`ing that. The current code `shift`s its inputs for non-inner join, removing the join-type modifier, which creates a fiendishly hard to track bug. Basically, this doesn't work:

```
my $sources = ['foo', [-left => 'bar', foo_id => 'id']];
is_deeply [ $sqlapg->select($sources) ], [ $sqlapg->select($sources) ];
```

### Motivation
Subtly mutating function inputs leads to hard-to-track bugs

### References
Sorry, none. Hopefully this summary plus the test modification (which now fails without the module change) makes clear the problem.
