### PR TITLE
listen & unlisten are blocking ops, so handle incoming notifications

### DIFF
--- a/lib/Mojo/Pg/Database.pm
+++ b/lib/Mojo/Pg/Database.pm
@@ -53,6 +53,7 @@ sub listen {
   my $dbh = $self->dbh;
   $dbh->do('LISTEN ' . $dbh->quote_identifier($name)) unless $self->{listen}{$name}++;
   $self->_watch;
+  $self->_notifications;
 
   return $self;
 }
@@ -127,6 +128,7 @@ sub unlisten {
   my $dbh = $self->dbh;
   $dbh->do('UNLISTEN ' . $dbh->quote_identifier($name));
   $name eq '*' ? delete $self->{listen} : delete $self->{listen}{$name};
+  $self->_notifications;
   $self->_unwatch unless $self->{waiting} || $self->is_listening;
 
   return $self;

--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -179,4 +179,16 @@ subtest 'Reset' => sub {
   };
 };
 
+subtest 'Call listen/unlisten immediately after notify' => sub {
+  my $pg = Mojo::Pg->new($ENV{TEST_ONLINE});
+  my @test;
+  $pg->pubsub->listen(pstest => sub { push @test, pop });
+  $pg->db->notify(pstest => 'works');
+  $pg->pubsub->listen(pstest2 => sub { });
+  is_deeply \@test, ['works'], 'right messages';
+  $pg->db->notify(pstest => 'works too');
+  $pg->pubsub->unlisten(pstest3 => sub { });
+  is_deeply \@test, ['works', 'works too'], 'right messages';
+};
+
 done_testing();


### PR DESCRIPTION
### Summary
This PR adds a `$pubsub->db->_notifications` call at the end of `$pubsub->db->listen` and `$pubsub->db->unlisten`, which should exist there as these two methods issue blocking SQL operations.

### Motivation
Without these changes, a `$pubsub->listen` on a new channel that directly follows a `$pg->db->notify` on one we're already listening on, would cause that notification to not be received in a timely manner (but potentially a lot later). I wanted to fix this.

### References
This PR fixes issue #77.