### PR TITLE
use backward compatible md5 password auth, fixes #85

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,6 +24,7 @@ jobs:
         image: postgres
         env:
           POSTGRES_PASSWORD: postgres
+          POSTGRES_INITDB_ARGS: --auth-host=md5
     steps:
       - uses: actions/checkout@v2
       - name: perl -V


### PR DESCRIPTION
### Summary
Mojo::Pg CI tests broke after a postgresql decision to change password authentication default on newer versions (14+), from md5 to scram-sha-256. The problem is that the libraries in use on the linux CI workflow different containers (libpq-dev and probably DBD::Pg) are not supporting that new auth method.

This change reverts the default in use on the postgres service from scram-sha-256 back to md5, so the "ONLINE" tests are able to connect and run again.

The alternative would be to apt-update / apt-install a newer versions for libpq-dev, but that way we will lose the simplicity of using preinstalled libraries. Also I tried that and didn't work, keeps complaining for newer versions of more dependences (I need to investigate further about this in the near future).

Info related: [PostgreSQL 14 and Recent SCRAM Authentication Changes – Should I Migrate to SCRAM?](https://www.percona.com/blog/postgresql-14-and-recent-scram-authentication-changes-should-i-migrate-to-scram/)

### Motivation
To fix CI.

### References
Issue #85 