### PR TITLE
Add _finish_when_safe to work around DBD::Pg race condition

### DIFF
--- a/lib/Mojo/Pg/Results.pm
+++ b/lib/Mojo/Pg/Results.pm
@@ -10,7 +10,7 @@ has [qw(db sth)];
 sub DESTROY {
   my $self = shift;
   return unless my $sth = $self->{sth};
-  $sth->finish unless --$sth->{private_mojo_results};
+  $self->finish unless --$sth->{private_mojo_results};
 }
 
 sub array { ($_[0]->_expand($_[0]->sth->fetchrow_arrayref))[0] }
@@ -23,7 +23,7 @@ sub hash { ($_[0]->_expand($_[0]->sth->fetchrow_hashref))[0] }
 
 sub expand { ++$_[0]{expand} and return $_[0] }
 
-sub finish { shift->sth->finish }
+sub finish { $_[0]->db->_finish_when_safe($_[0]->sth) }
 
 sub hashes { _collect($_[0]->_expand(@{$_[0]->sth->fetchall_arrayref({})})) }
 


### PR DESCRIPTION
### Summary

Adds a private method `_finish_when_safe` in `Mojo::Pg::Database`, used by `Mojo::Pg::Results` instead of calling `finish` directly on DBI statement handles.

### Motivation

There is a race condition in `DBD::Pg` which causes in-progress statement handles to be finished inappropriately when old statement handles are finished during an async DB query. This issue was previously concealed by a memory leak in `Mojo::Promise` which kept affected objects alive more or less indefinitely. Now that the leak is fixed, this `DBD::Pg` bug can cause async DB operations in close proximity to fail.

This change works around the problem by postponing finish operations if an async query is in progress. Most of the time there will be no such query in progress, and the handle is finished immediately. Where unsafe, a temporary array is created to hold any incoming statement handles, and the contents of this array (if any) are finished when the async operation completes.

### References

- Problem report and analysis: https://github.com/mojolicious/mojo/issues/2276
- Underlying `DBD::Pg` issue: https://github.com/bucardo/dbdpg/issues/105
- Memory leak fix which exposed the issue: https://github.com/mojolicious/mojo/pull/2268
